### PR TITLE
Re-create the password hash if it ends with a period

### DIFF
--- a/app/processing.py
+++ b/app/processing.py
@@ -39,5 +39,8 @@ def do_validate_password(input):
 
 
 def do_passwdsalt(password):
-    return crypt.crypt(password, crypt.mksalt(crypt.METHOD_SHA512))
+    hash_result = crypt.crypt(password, crypt.mksalt(crypt.METHOD_SHA512))
+    while hash_result.endswith('.'):
+        hash_result = crypt.crypt(password, crypt.mksalt(crypt.METHOD_SHA512))
+    return hash_result
 


### PR DESCRIPTION
Resolve an issue with the hash ending in . which does not seem to work with pam authentication. This will prevent the hash from ending with a period. 